### PR TITLE
Change url to path func

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,8 +85,8 @@ Installation
 
     urlpatterns = patterns(
         '',
-        url(r'^jet/', include('jet.urls', 'jet')),  # Django JET URLS
-        url(r'^admin/', include(admin.site.urls)),
+        path('jet/', include('jet.urls', 'jet')),  # Django JET URLS
+        path('admin/', include(admin.site.urls)),
         ...
     )
 
@@ -128,9 +128,9 @@ Dashboard installation
 
     urlpatterns = patterns(
         '',
-        url(r'^jet/', include('jet.urls', 'jet')),  # Django JET URLS
-        url(r'^jet/dashboard/', include('jet.dashboard.urls', 'jet-dashboard')),  # Django JET dashboard URLS
-        url(r'^admin/', include(admin.site.urls)),
+        path('jet/', include('jet.urls', 'jet')),  # Django JET URLS
+        path('jet/dashboard/', include('jet.dashboard.urls', 'jet-dashboard')),  # Django JET dashboard URLS
+        path('admin/', include(admin.site.urls)),
         ...
     )
 


### PR DESCRIPTION
If focusing on Django >= 3.0 only it would be good to use path() instead of url()